### PR TITLE
Pave way for Block Helper to provide tooltips

### DIFF
--- a/apron-stapi/src/main/java/io/github/betterthanupdates/apron/stapi/blockhelper/TooltipRegistrar.java
+++ b/apron-stapi/src/main/java/io/github/betterthanupdates/apron/stapi/blockhelper/TooltipRegistrar.java
@@ -1,0 +1,31 @@
+package io.github.betterthanupdates.apron.stapi.blockhelper;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.mine_diver.unsafeevents.listener.EventListener;
+import net.minecraft.item.ItemStack;
+import net.modificationstation.stationapi.api.client.event.gui.screen.container.TooltipBuildEvent;
+
+public class TooltipRegistrar {
+
+	private static final List<TooltipBuilder> tooltipBuilders = new ArrayList<>();
+
+	@EventListener
+	public final void onBlocksInit(TooltipBuildEvent tooltipEvent) {
+		tooltipBuilders.forEach(b -> b.handleStack(tooltipEvent.itemStack, tooltipEvent::add));
+	}
+
+	public static void registerTooltipBuilder(TooltipBuilder builder) {
+		tooltipBuilders.add(builder);
+	}
+
+	public interface TooltipBuilder {
+		void handleStack(ItemStack stack, LineAdder lineAdder);
+	}
+
+	/* Compat for Block Helper - its JDK target is 6... Too low for regular Consumer<String>s */
+	public interface LineAdder {
+		void addLine(String line);
+	}
+
+}

--- a/apron-stapi/src/main/resources/fabric.mod.json
+++ b/apron-stapi/src/main/resources/fabric.mod.json
@@ -28,6 +28,7 @@
     ],
     "stationapi:event_bus": [
       "io.github.betterthanupdates.apron.stapi.ApronStAPICompat",
+      "io.github.betterthanupdates.apron.stapi.blockhelper.TooltipRegistrar",
       "io.github.betterthanupdates.apron.stapi.dataconverter.ModDataConverter",
       "io.github.betterthanupdates.apron.stapi.resources.ApronResourceEvents"
     ]


### PR DESCRIPTION
Since I cannot easily add an event listener to Block Helper and register it properly, this would be a semi-good way to provide support for the tooltip module.
I agree - this is not the best way to do things, but it works and could also be used by other mods that Apron loads.
